### PR TITLE
Update .eslintrc.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,9 @@ module.exports = {
     "curly": ["error", "multi-line"],
     "import/no-extraneous-dependencies": "off",
     "require-await": 0,
+    
+    // /src/renderer/plugins/vuetify.js imports fonts for offline use. eslint detects these as "unused-expressions".
+    "no-unused-expressions": "off",
 
     "global-require": 0,
     'import/no-unresolved': 0,


### PR DESCRIPTION
/src/renderer/plugins/vuetify.js imports fonts for offline use. 

Eslint detects these as "unused-expressions".

This causes the initial `yarn` command to fail and exit with code 1.

Although it failed, a `yarn run dev` still works.

Adding this line, the command initial `yarn` will work as expected.
Maybe there is a better solution here. Globally disabling this rule can have other side effects. They won't be as hard as we're not in a size-critical environment.

Hope this helps.