### PR TITLE
Added a meta tag charset: "utf-8" for solving problem with cyrillic

### DIFF
--- a/template/src/renderer/nuxt.config.js
+++ b/template/src/renderer/nuxt.config.js
@@ -8,7 +8,8 @@
 module.exports = {
   mode: 'spa', // or 'universal'
   head: {
-    title: '{{name}}'
+    title: '{{name}}',
+    meta: [{ charset: "utf-8" }]
   },
   loading: false,
   plugins: [


### PR DESCRIPTION
Hello,

Before there was a  problem with cyrillic when i made build version, example: 
![image](https://user-images.githubusercontent.com/4071686/87382475-3b271b00-c5c1-11ea-96e9-cf02d31b9639.png)

After  meta tag added the problem solved.
