### PR TITLE
Update nuxt.config.js mode -> ssr property

### DIFF
--- a/template/src/renderer/nuxt.config.js
+++ b/template/src/renderer/nuxt.config.js
@@ -6,7 +6,7 @@
 
 
 module.exports = {
-  mode: 'spa', // or 'universal'
+  ssr: false,
   head: {
     title: '{{name}}',
     meta: [{ charset: "utf-8" }]


### PR DESCRIPTION
The [`mode` property](https://nuxtjs.org/docs/2.x/configuration-glossary/configuration-mode/) is deprecated and replaced by `ssr: true|false`

https://nuxtjs.org/docs/2.x/configuration-glossary/configuration-ssr

I believe `ssr: false` makes sense in the context of pre-built Electron apps