### PR TITLE
fix webpack plugin support

### DIFF
--- a/template/.electron-nuxt/renderer/nuxt.config.js
+++ b/template/.electron-nuxt/renderer/nuxt.config.js
@@ -66,7 +66,17 @@ const mergeConfig = customConfig => {
     if(baseConfig.build === undefined) baseConfig.build = {};
     baseConfig.build.extend = baseExtend;
   }
-  return deepmerge(baseConfig, customConfig);
+
+  if (customConfig.build !== undefined && customConfig.build.plugins !== undefined) {
+    // webpack config plugins should not use deep merge
+    let { plugins, ...rest } = customConfig.build;
+    customConfig.build = rest;
+    let result = deepmerge(baseConfig, customConfig);
+    result.build.plugins = plugins;
+    return result;
+  } else {
+    return deepmerge(baseConfig, customConfig);
+  }
 }
 
 


### PR DESCRIPTION
Add `build.plugins` to `src/renderer/nuxt.config.js` will cause the following error: 

```
WebpackOptionsValidationError: Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
  - configuration.plugins[2] misses the property 'apply'.
```

That is caused by `deepmerge` [here](https://github.com/michalzaq12/electron-nuxt/blob/5c57881c628bbd0b2192a652951af80e2ae703c2/template/.electron-nuxt/renderer/nuxt.config.js#L69).

Fixed in this PR.
